### PR TITLE
Help RMarkdown render the list correctly

### DIFF
--- a/vignettes/LessVolume-MoreCreativity.Rmd
+++ b/vignettes/LessVolume-MoreCreativity.Rmd
@@ -538,6 +538,7 @@ secure in their ability to use these functions.
 
 ## Some other things
 The `mosaic` package includes some other things, too
+
  * data sets (they have now been moved to separate `mosaicData` and `NHANES` packages)
  * xtras: `xchisq.test()`, `xpnorm()`, `xqqmath()`
    * these functions add a bit of extra output to the similarly named functions that don't have a leading `x`


### PR DESCRIPTION
RMarkdown has an annoying misfeature - if you don't precede an ordered or unordered list with a blank line, it fails to render as a list. So the vignette displays as

The mosaic package includes some other things, too * data sets (they have now been moved to separate mosaicData and NHANES packages) * xtras: xchisq.test(), xpnorm(), xqqmath() * these functions add a bit of extra output to the similarly named functions that don’t have a leading x * mplot() * mplot(HELPrct) interactive plot creation * replacements for plot() in some situations * simplified histogram() controls (e.g., width) * simplified ways to add onto lattice plots (add = TRUE works in many situations)


Note that GitHub renders this particular chunk of Markdown correctly.