### PR TITLE
Fix typo in binom.test() part of Vignette.

### DIFF
--- a/vignettes/Resampling.Rnw
+++ b/vignettes/Resampling.Rnw
@@ -363,7 +363,7 @@ xpbinom(239, prob = 0.5, size = 428)
 Of course, \R{} can handle all of these little details and do the entire 
 calculation for us if we use the \function{binom.test} function.
 <<>>=
-binom.test(x = 240, n = 248)
+binom.test(x = 240, n = 428)
 @
 
 Even if you want to use the deterministic probability calculation (using either


### PR DESCRIPTION
Unless I've completely misunderstood, `n=248` should be `n=428`.