### PR TITLE
Fix for rlang 1.2.0

### DIFF
--- a/R/do.R
+++ b/R/do.R
@@ -522,12 +522,12 @@ setMethod(
   signature(e1 = "repeater", e2="ANY"),
   function (e1, e2) 
   {
-    e2_lazy <- rlang::enquo(e2)
-    #		e2unevaluated = substitute(e2)
-    #		if ( ! is.function(e2) ) {
-    #      frame <- parent.frame()
-    #			e2 = function(){eval(e2unevaluated, envir=frame) }   
-    #		}
+    # `enquo()` is:
+    # - Not needed since `...` can't be passed to an operator.
+    # - Unusable here, because dispatch forces arguments, which causes `enquo()`
+    #   to return a forced promise.
+    e2_expr <- substitute(e2)
+    e2_env <- parent.frame()
     n = e1@n
     
     cull = e1@cull
@@ -543,9 +543,9 @@ setMethod(
                 "  * Set seed with set.rseed().\n", 
                 "  * Disable this message with options(`mosaic:parallelMessage` = FALSE)\n")
       }
-      parallel::mclapply( integer(n), function(...) { cull(rlang::eval_tidy(e2_lazy)) } )
+      parallel::mclapply( integer(n), function(...) { cull(eval(e2_expr, e2_env)) } )
     } else {
-      lapply( integer(n), function(...) { cull(rlang::eval_tidy(e2_lazy)) } )
+      lapply( integer(n), function(...) { cull(eval(e2_expr, e2_env)) } )
     }
     
     if (out.mode=='default') {  # is there any reason to be fancier?
@@ -563,14 +563,14 @@ setMethod(
       # we get mutliple parts here if expression involves, for example, ::
       # just grab last part. (paste()ing would be out of order
       alt_name <- tryCatch(
-        tail(as.character(rhs(e2_lazy)[[1]]), 1),
+        tail(as.character(e2_expr[[1]]), 1),
         error = function(e) "result"
       )
       names(result) <- mosaicCore::nice_names(names(result))
       names(result)[names(result) == "..result.."] <- 
         if(mosaicCore::nice_names(alt_name) == alt_name) alt_name else "result"
     }
-    attr(result, "lazy") <- e2_lazy
+    attr(result, "lazy") <- e2_expr
     if (out.mode == "data.frame") attr(result, "culler") <- cull
     return(result)
   })

--- a/tests/testthat/test-do.R
+++ b/tests/testthat/test-do.R
@@ -11,6 +11,12 @@ test_that("naming as expected", {
 })
 
 
+test_that("expression is re-evaluated on each iteration", {
+  set.seed(1)
+  result <- do(5) * mean(~cesd, data = resample(mosaicData::HELPrct))
+  expect_gt(length(unique(result[[1]])), 1)
+})
+
 test_that("dimension as expected", {
   expect_equal(ignore_attr = TRUE,  dim( do(2) * mean(~cesd, data=mosaicData::HELPrct)), c(2,1))
   expect_equal(ignore_attr = TRUE,  dim( do(2) * var(~cesd, data=mosaicData::HELPrct)), c(2,1))


### PR DESCRIPTION
For forced arguments, `enquo()` capture values rather than expressions.

S4 dispatch does force arguments, and capturing the expression only used to work by luck, due to the peculiar way R forces arguments during dispatch. The next version of rlang (to be released soon) uses the new C API of R to capture expressions, which causes mosaic to fail checks because of this.